### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/Shebelieves670032/621e2cae-2535-43ae-ad90-f7c2a464a700/92349bd0-ff92-47bb-ba53-26fc0ec751d9/_apis/work/boardbadge/43f73e5b-a2e8-4995-8947-4a5f73b0cd00)](https://dev.azure.com/Shebelieves670032/621e2cae-2535-43ae-ad90-f7c2a464a700/_boards/board/t/92349bd0-ff92-47bb-ba53-26fc0ec751d9/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Shebelieves670032/621e2cae-2535-43ae-ad90-f7c2a464a700/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.